### PR TITLE
Basic gradle CI workflow 

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,26 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew build

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,7 +2,7 @@ name: Android CI
 
 on:
   push:
-    #branches: [ "master" ]
+    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,7 +2,7 @@ name: Android CI
 
 on:
   push:
-    branches: [ "master" ]
+    #branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -20,7 +20,5 @@ jobs:
         distribution: 'temurin'
         cache: gradle
 
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew build


### PR DESCRIPTION
See it being executed after temporary removing the branch name limitation to "`master`" in 53b6d2c9a853d00df31d687b5c8e289ce12dafb2 in my fork: https://github.com/stefanb/silent-sms-ping/actions/runs/5529420817 or https://github.com/stefanb/silent-sms-ping/actions/runs/5540588184/jobs/10112875599
