### PR TITLE
Lower minSdkVersion to 23 (Android 6, 2015)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ android {
 
     defaultConfig {
         applicationId 'com.telefoncek.silentsms.detector'
-        minSdkVersion 31
+        minSdkVersion 23
         targetSdkVersion 33
         versionCode 6
         versionName "4"


### PR DESCRIPTION
Previous `minSdkVersion 31` was unnecessarily limiting users to [Android 12 and newer, with currently only 40% market share](https://apilevels.com/). Supporting older API would allow wider use, even on older burner phones etc.

At least 23 is required for [android.content.Context#getSystemService](https://developer.android.com/reference/android/content/Context#getSystemService(java.lang.Class%3CT%3E)) in:
https://github.com/MatejKovacic/silent-sms-ping/blob/9734022b71fee64865b026fa7c84638cab7ae6f4/app/src/main/java/com/telefoncek/silentsms/detector/MainActivity.java#L105

Fixes https://github.com/MatejKovacic/silent-sms-ping/issues/8 for older devices (Android 6 - 11).
